### PR TITLE
正規化処理のプログラムを修正(正規化を戻す処理を不要にしました。)

### DIFF
--- a/AutoEncoder_learning.py
+++ b/AutoEncoder_learning.py
@@ -44,10 +44,16 @@ def create_FT_model(hidden, w_AE1, w_AE2, w_AE3):  # ファインチューニン
     return FT_model
 
 
-
 df_tweet_dataset = pd.read_csv('./Dataset/Dataset.csv', encoding='utf_8_sig')
 
 good_num = df_tweet_dataset['いいね数']
+
+
+past_user_information = df_tweet_dataset.drop(['Unnamed: 0', 'ツイートID', 'ツイートText', 'ツイートURL', 'キーワード', 'ツイート時刻', '鍵垢flag', 'ユーザID', 'いいね数'], axis=1)
+past_user_information = past_user_information.to_numpy()
+
+np.save('./saved_data/past_user_infomation.npy', past_user_information)
+
 
 x_train, x_test, t_train, t_test = train_test_split(df_tweet_dataset, good_num, train_size=0.8, random_state=0)
 

--- a/Good_Scouter_System.py
+++ b/Good_Scouter_System.py
@@ -183,7 +183,8 @@ get_sentence_feature = Model(inputs=LSTM_Classification.input, outputs=LSTM_Clas
 
 test_sentence_feature = get_sentence_feature([tweet_w2v])
 
-normalization_user_information = np.load('./saved_data/normalization_user_information.npy')
+# normalization_user_information = np.load('./saved_data/normalization_user_information.npy')
+past_user_information = np.load('./saved_data/past_user_information.npy')
 
 test_input = []
 test_input.append(follow)
@@ -192,13 +193,12 @@ test_input.append(int(time))
 test_input.append(total_tw)
 test_input.extend(test_sentence_feature[0])
 test_input = np.array(test_input)
-test_input = test_input.reshape(-1, normalization_user_information.shape[1])
-print(test_input)
+test_input = test_input.reshape(-1, past_user_information.shape[1])
+# print(test_input)
 
 mm = preprocessing.MinMaxScaler()
-normalization_user_inv = mm.inverse_transform(normalization_user_information)
 
-tweet_data_include_candidate_tweet = np.insert(normalization_user_inv, normalization_user_inv.shape[0], test_input, axis=0)
+tweet_data_include_candidate_tweet = np.insert(past_user_information, past_user_information.shape[0], test_input, axis=0)
 
 normalization_tweet_data_include_candidate_tweet = mm.fit_transform(tweet_data_include_candidate_tweet)
 


### PR DESCRIPTION
これまでシステム上では正規化したユーザー情報を一旦もとに戻してから、入力データを加えた正規化を行っていましたが、2度手間なので、そのままのユーザー情報を保存したものを読み込むようにしました。(ユーザー情報はignoreです。)